### PR TITLE
return the map instance reference onMapReady

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,51 @@ const types = [
 function App() {
   const [pushPins, setPushPins] = useState([]);
   const [mapReady, setMapReady] = useState(false);
+  const [map, setMap] = useState(null);
+  const [polygonAdded, setPolygonAdded] = useState(false);
+
+  // https://docs.microsoft.com/en-us/bingmaps/v8-web-control/map-control-concepts/geojson-module-examples/read-local-geojson-object-example
+  function drawPolygon() {
+    if (!polygonAdded) {
+      const myGeoJson = {
+        coordinates: [
+          [
+            [-222.6264758, 34.789661],
+            [-222.6889734, 34.7861691],
+            [-222.6362328, 34.765536],
+            [-222.6582792, 34.7179505],
+            [-222.6070504, 34.7486121],
+            [-222.5641532, 34.7179882],
+            [-222.5785546, 34.759613],
+            [-222.530398, 34.7860953],
+            [-222.595456, 34.7881909],
+            [-222.6083834, 34.8318783],
+            [-222.6264758, 34.789661],
+          ],
+        ],
+        type: "Polygon",
+      };
+
+      //Load the GeoJson Module.
+      window.Microsoft.Maps.loadModule("Microsoft.Maps.GeoJson", function () {
+        //Parse the GeoJson object into a Bing Maps shape.
+        const shape = window.Microsoft.Maps.GeoJson.read(myGeoJson, {
+          polygonOptions: {
+            fillColor: "#0d8f2b7f",
+            strokeColor: "#0d8f2b",
+            strokeThickness: 5,
+          },
+        });
+
+        //Add the shape to the map.
+        if (!polygonAdded) {
+          map.current.entities.push(shape);
+          setPolygonAdded(true);
+        }
+      });
+    }
+  }
+
   function addPushPin() {
     Promise.all(
       types.map((type) => {
@@ -65,7 +110,11 @@ function App() {
   return (
     <div className="map__container">
       <BingMapsReact
-        // onMapReady={() => setMapReady(true)}
+        // onMapReady={({ map }) => {
+        //   setMapReady(true);
+        //   setMap(map);
+        //   drawPolygon();
+        // }}
         bingMapsKey={process.env.REACT_APP_BINGMAPS_KEY}
         pushPins={pushPins}
         mapOptions={{
@@ -74,6 +123,7 @@ function App() {
           enableHighDpi: true,
         }}
         viewOptions={{
+          // center: { latitude: 34.7689, longitude: 137.3917 },
           zoom: 12,
           customMapStyle: {
             elements: {

--- a/src/BingMapsReact.test.js
+++ b/src/BingMapsReact.test.js
@@ -146,3 +146,15 @@ it("should render with push pins with info boxes", () => {
     />
   );
 });
+
+it("should return the map reference on mapReady", () => {
+  initGlobal();
+  render(
+    <BingMapsReact
+      onMapReady={({ map }) => {
+        expect(map).toHaveProperty('current')
+        expect(Object.keys(map.current)).toEqual(['setOptions', 'setView', 'getCenter', 'entities'])
+      }}
+    />
+  );
+});

--- a/src/components/BingMapsReact.jsx
+++ b/src/components/BingMapsReact.jsx
@@ -138,7 +138,7 @@ export default function BingMapsReact({
         Maps
       );
     }
-    onMapReady && onMapReady();
+    onMapReady && onMapReady({ map });
   }, [
     addPushpinsWithInfoboxes,
     bingMapsKey,


### PR DESCRIPTION
I was looking for a way to tap into additional features of the Bing maps.  These features go beyond what is available through the component itself.  In particular I am looking to use `Microsoft.Maps.GeoJson`. 

I made one small, non-breaking change to return the map instance onMapReady.  I also added an example in `App.jsx` but kept the code commented out that actually runs the GeoJson example.  

I wrote one test that checks that the map instance is being returned onMapReady.